### PR TITLE
feat: add ignore cache option

### DIFF
--- a/.github/workflows/dirty-waters.yml
+++ b/.github/workflows/dirty-waters.yml
@@ -19,6 +19,11 @@ on:
       - "**/pnpm-lock.yaml"
       - "**/pom.xml"
   workflow_dispatch:
+    inputs:
+      ignore_cache:
+        description: "Ignore the repository cache for this run"
+        required: false
+        default: "false"
 
 jobs:
   analyze:
@@ -40,7 +45,7 @@ jobs:
       - name: Run Static Dirty Waters analysis
         id: static-analysis
         if: steps.check-first-run.outputs.is_first_run == 'true'
-        uses: chains-project/dirty-waters-action@v1.5
+        uses: chains-project/dirty-waters-action@v1.7
         with:
           # example args, change as needed
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -50,11 +55,12 @@ jobs:
           comment_on_commit: true # Optional: comments on commits (if not PR/if above is false) if high severity issues are found
           latest_commit_sha: ${{ github.sha }}
           github_event_before: ${{ github.event.before }}
+          ignore_cache: ${{ github.event.inputs.ignore_cache }}
 
       - name: Run Differential Dirty Waters Analysis
         id: differential-analysis
         if: steps.check-first-run.outputs.is_first_run != 'true'
-        uses: chains-project/dirty-waters-action@v1.5
+        uses: chains-project/dirty-waters-action@v1.7
         with:
           # example args, change as needed
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -65,3 +71,4 @@ jobs:
           comment_on_commit: true # Optional: comments on commits (if not PR/if above is false) if high severity issues are found
           latest_commit_sha: ${{ github.sha }}
           github_event_before: ${{ github.event.before }}
+          ignore_cache: ${{ github.event.inputs.ignore_cache }}

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ SSC issues currently checked for:
 | comment_on_commit     | Comment on commit if high severity issues found                                                    | No       | false          |
 | latest_commit_sha     | Latest commit SHA, used to comment on commits                                                      | Yes      | -              |
 | github_event_before   | GitHub event before SHA, to retrieve the previous cache key                                        | Yes      | -              |
+| ignore_cache          | Ignore the repository cache for this run (true/false)                                              | No       | false          |

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,10 @@ inputs:
   github_event_before:
     description: 'GitHub event before SHA, to retrieve the previous cache key'
     required: true
+  ignore_cache:
+    description: 'Ignore the repository cache for this run'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -92,11 +96,10 @@ runs:
     - name: Restore cache
       uses: actions/cache/restore@v4
       id: restore-cache
+      if: inputs.ignore_cache != 'true'
       with:
         path: tool/cache
         key: dirty-waters-cache-${{ runner.os }}-${{ inputs.project_repo }}-${{ inputs.github_event_before }}
-        restore-keys: |
-          dirty-waters-cache-${{ runner.os }}-${{ inputs.project_repo }}-
 
     - name: Create cache directory
       if: steps.restore-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
This way, we can ignore the previously acquired cache if we want to do so. The example workflow also includes the input being present in `workflow_dispatch`