### PR TITLE
chore: implement feedback from Eric

### DIFF
--- a/.github/workflows/bump_example_version.yml
+++ b/.github/workflows/bump_example_version.yml
@@ -25,10 +25,10 @@ jobs:
 
           echo "commit_sha=$COMMIT_SHA" >> $GITHUB_ENV
 
-      - name: Update dirty_waters_version in the example workflow to the repo's latest tag
+      - name: Update dirty_waters_version in the action to the repo's latest tag
         run: |
           LATEST_TAG=$(git ls-remote --tags https://github.com/chains-project/dirty-waters.git | awk -F/ '{print $3}' | sort -V | tail -n1)
-          sed -i "s/dirty_waters_version: v[0-9.]\+/dirty_waters_version: ${LATEST_TAG}/g" ./example_workflow.yml
+          sed -i "s/DIRTY_WATERS_VERSION=\".*\"/DIRTY_WATERS_VERSION=\"$LATEST_TAG\"/" action.yml
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5.1.0

--- a/.github/workflows/bump_example_version.yml
+++ b/.github/workflows/bump_example_version.yml
@@ -25,6 +25,11 @@ jobs:
 
           echo "commit_sha=$COMMIT_SHA" >> $GITHUB_ENV
 
+      - name: Update dirty_waters_version in the example workflow to the repo's latest tag
+        run: |
+          LATEST_TAG=$(git ls-remote --tags https://github.com/chains-project/dirty-waters.git | awk -F/ '{print $3}' | sort -V | tail -n1)
+          sed -i "s/dirty_waters_version: v[0-9.]\+/dirty_waters_version: ${LATEST_TAG}/g" ./example_workflow.yml
+
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5.1.0
         with:

--- a/.github/workflows/bump_example_version.yml
+++ b/.github/workflows/bump_example_version.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
 
@@ -26,7 +26,7 @@ jobs:
           echo "commit_sha=$COMMIT_SHA" >> $GITHUB_ENV
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v5.1.0
         with:
           commit_message: "Bump dirty-waters-action version to ${{ env.commit_sha }}"
           branch: ${{ github.head_ref }}

--- a/.github/workflows/bump_example_version.yml
+++ b/.github/workflows/bump_example_version.yml
@@ -1,0 +1,32 @@
+name: Bump Action version
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update dirty-waters-action version
+        run: |
+          COMMIT_SHA=$(git rev-parse HEAD)
+
+          # Use sed to update occurrences of the version in the workflow file
+          sed -i "s/chains-project\/dirty-waters-action@v[0-9.]\+/chains-project\/dirty-waters-action@${COMMIT_SHA}/g" ./example_workflow.yml
+
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_ENV
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Bump dirty-waters-action version to ${{ env.commit_sha }}"
+          branch: ${{ github.head_ref }}

--- a/.github/workflows/dirty-waters.yml
+++ b/.github/workflows/dirty-waters.yml
@@ -47,12 +47,9 @@ jobs:
           # example args, change as needed
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dirty_waters_version: v0.49.0
-          project_repo: ${{ github.repository }}
           package_manager: npm # Change this according to your project
           allow_pr_comment: true # Optional: comments on PRs if high severity issues are found
           comment_on_commit: true # Optional: comments on commits (if not PR/if above is false) if high severity issues are found
-          latest_commit_sha: ${{ github.sha }}
-          github_event_before: ${{ github.event.before }}
           ignore_cache: ${{ github.event.inputs.ignore_cache }}
 
       - name: Run Differential Dirty Waters Analysis
@@ -63,11 +60,8 @@ jobs:
           # example args, change as needed
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dirty_waters_version: v0.49.0
-          project_repo: ${{ github.repository }}
           differential_analysis: true
           package_manager: npm # Change this according to your project
           allow_pr_comment: true # Optional: comments on PRs if high severity issues are found
           comment_on_commit: true # Optional: comments on commits (if not PR/if above is false) if high severity issues are found
-          latest_commit_sha: ${{ github.sha }}
-          github_event_before: ${{ github.event.before }}
           ignore_cache: ${{ github.event.inputs.ignore_cache }}

--- a/.github/workflows/dirty-waters.yml
+++ b/.github/workflows/dirty-waters.yml
@@ -2,17 +2,12 @@ name: Dirty Waters Analysis
 
 on:
   pull_request:
-    paths:
-      - "**/package.json"
-      - "**/package-lock.json"
-      - "**/yarn.lock"
-      - "**/pnpm-lock.yaml"
-      - "**/pom.xml"
   push:
     branches:
       - main
       - master
     paths:
+      # Include the one(s) relevant for your use case
       - "**/package.json"
       - "**/package-lock.json"
       - "**/yarn.lock"

--- a/.github/workflows/dirty-waters.yml
+++ b/.github/workflows/dirty-waters.yml
@@ -23,6 +23,8 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    permissions:
+      persist-credentials: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dirty-waters.yml
+++ b/.github/workflows/dirty-waters.yml
@@ -42,10 +42,11 @@ jobs:
       - name: Run Static Dirty Waters analysis
         id: static-analysis
         if: steps.check-first-run.outputs.is_first_run == 'true'
-        uses: chains-project/dirty-waters-action@v1.7
+        uses: chains-project/dirty-waters-action@v1.10
         with:
           # example args, change as needed
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          dirty_waters_version: v0.49.0
           project_repo: ${{ github.repository }}
           package_manager: npm # Change this according to your project
           allow_pr_comment: true # Optional: comments on PRs if high severity issues are found
@@ -57,10 +58,11 @@ jobs:
       - name: Run Differential Dirty Waters Analysis
         id: differential-analysis
         if: steps.check-first-run.outputs.is_first_run != 'true'
-        uses: chains-project/dirty-waters-action@v1.7
+        uses: chains-project/dirty-waters-action@v1.10
         with:
           # example args, change as needed
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          dirty_waters_version: v0.49.0
           project_repo: ${{ github.repository }}
           differential_analysis: true
           package_manager: npm # Change this according to your project

--- a/.github/workflows/publish-release-tag.yml
+++ b/.github/workflows/publish-release-tag.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0 # Fetch all history for tags
 

--- a/.github/workflows/publish-release-tag.yml
+++ b/.github/workflows/publish-release-tag.yml
@@ -25,8 +25,15 @@ jobs:
         id: generate-new-tag
         run: |
           current_tag=${{ env.LATEST_TAG }}
-          IFS='.' read -r major minor <<< "${current_tag#v}"
-          new_tag="v$major.$((minor + 1))"
+          IFS='.' read -r -a tag_parts <<< "$current_tag"
+          major=${tag_parts[0]}
+          minor=${tag_parts[1]}
+          if [ ${#tag_parts[@]} -eq 2 ]; then
+            patch=0
+          else
+            patch=${tag_parts[2]}
+          fi
+          new_tag="v$major.$minor.$((patch + 1))"
           echo "NEW_TAG=$new_tag" >> $GITHUB_ENV
 
       - name: Create and push tag

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This action runs [Dirty Waters](https://github.com/chains-project/dirty-waters) on your repository to analyze dependencies for Software Supply Chain (SSC) issues.
 Add this workflow to your repository to analyze dependencies in your pull requests
-(change/add inputs as needed -- details in [action.yml](./action.yml)). An example of a workflow that uses this action is available in [.github/workflows/dirty-waters.yml](./.github/workflows/dirty-waters.yml).
+(change/add inputs as needed -- details in [action.yml](./action.yml)). An example of a workflow that uses this action is available in [example_workflow.yml](./example_workflow.yml).
 
 The action will:
 

--- a/README.md
+++ b/README.md
@@ -27,24 +27,24 @@ SSC issues currently checked for:
 
 ### Inputs
 
-| Input                 | Description                                                                                        | Required | Default        |
-| --------------------- | -------------------------------------------------------------------------------------------------- | -------- | -------------- |
-| github_token          |                                                                                                    | Yes      | -              |
-| dirty_waters_version  | Dirty Waters version to use                                                                        | No       | latest         |
-| project_repo          | Repository name (owner/repo)                                                                       | Yes      | -              |
-| version_old           | Base version/ref to analyze,                                                                       | No       | HEAD           |
-| version_new           | New version/ref for diff analysis                                                                  | No       | HEAD^          |
-| differential_analysis | Whether to perform differential analysis (true/false)                                              | No       | false          |
-| package_manager       | Package manager (npm, yarn-classic, yarn-berry, pnpm, maven)                                       | Yes      | -              |
-| name_match            | Compare the package names with the name in the in the package.json file. Will slow down execution. | No       | false          |
-| pnpm_scope            | Extract dependencies from pnpm with a specific scope                                               | No       | -              |
-| specified_smells      | Specify the smells to check for                                                                    | No       | all            |
-| debug                 | Enable debug mode                                                                                  | No       | false          |
-| no_gradual_report     | Disable gradual report functionality                                                               | No       | false          |
-| fail_on_high_severity | Fail CI on high severity issues                                                                    | No       | true           |
-| x_to_fail             | Percentage threshold to break CI on non-high severity issues (per type of issue)                   | No       | 5% of packages |
-| allow_pr_comment      | Post analysis results as a PR comment if CI breaks                                                 | No       | true           |
-| comment_on_commit     | Post analysis results as a commit comment if CI breaks                                             | No       | false          |
-| latest_commit_sha     | Latest commit SHA, used to comment on commits                                                      | Yes      | -              |
-| github_event_before   | GitHub event before SHA, to retrieve the previous cache key                                        | Yes      | -              |
-| ignore_cache          | Ignore the repository cache for this run (true/false)                                              | No       | false          |
+| Input                 | Description                                                                                        | Required | Default                    |
+| --------------------- | -------------------------------------------------------------------------------------------------- | -------- | -------------------------- |
+| github_token          |                                                                                                    | Yes      | -                          |
+| dirty_waters_version  | Dirty Waters version to use                                                                        | No       | latest                     |
+| project_repo          | Repository name (owner/repo)                                                                       | No       | {{ github.repository }}    |
+| version_old           | Base version/ref to analyze,                                                                       | No       | HEAD                       |
+| version_new           | New version/ref for diff analysis                                                                  | No       | HEAD^                      |
+| differential_analysis | Whether to perform differential analysis (true/false)                                              | No       | false                      |
+| package_manager       | Package manager (npm, yarn-classic, yarn-berry, pnpm, maven)                                       | Yes      | -                          |
+| name_match            | Compare the package names with the name in the in the package.json file. Will slow down execution. | No       | false                      |
+| pnpm_scope            | Extract dependencies from pnpm with a specific scope                                               | No       | -                          |
+| specified_smells      | Specify the smells to check for                                                                    | No       | all                        |
+| debug                 | Enable debug mode                                                                                  | No       | false                      |
+| no_gradual_report     | Disable gradual report functionality                                                               | No       | false                      |
+| fail_on_high_severity | Fail CI on high severity issues                                                                    | No       | true                       |
+| x_to_fail             | Percentage threshold to break CI on non-high severity issues (per type of issue)                   | No       | 5% of packages             |
+| allow_pr_comment      | Post analysis results as a PR comment if CI breaks                                                 | No       | true                       |
+| comment_on_commit     | Post analysis results as a commit comment if CI breaks                                             | No       | false                      |
+| latest_commit_sha     | Latest commit SHA, used to comment on commits                                                      | No       | ${{ github.sha }}          |
+| github_event_before   | GitHub event before SHA, to retrieve the previous cache key                                        | No       | ${{ github.event.before }} |
+| ignore_cache          | Ignore the repository cache for this run (true/false)                                              | No       | false                      |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ SSC issues currently checked for:
 | pnpm_scope            | Extract dependencies from pnpm with a specific scope                                               | No       | -                          |
 | specified_smells      | Specify the smells to check for                                                                    | No       | all                        |
 | debug                 | Enable debug mode                                                                                  | No       | false                      |
-| no_gradual_report     | Disable gradual report functionality                                                               | No       | false                      |
+| gradual_report        | Enable gradual report functionality                                                                | No       | true                       |
 | fail_on_high_severity | Fail CI on high severity issues                                                                    | No       | true                       |
 | x_to_fail             | Percentage threshold to break CI on non-high severity issues (per type of issue)                   | No       | 5% of packages             |
 | allow_pr_comment      | Post analysis results as a PR comment if CI breaks                                                 | No       | true                       |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ SSC issues currently checked for:
 | Input                 | Description                                                                                        | Required | Default                    |
 | --------------------- | -------------------------------------------------------------------------------------------------- | -------- | -------------------------- |
 | github_token          |                                                                                                    | Yes      | -                          |
-| dirty_waters_version  | Dirty Waters version to use                                                                        | No       | latest                     |
 | project_repo          | Repository name (owner/repo)                                                                       | No       | {{ github.repository }}    |
 | version_old           | Base version/ref to analyze,                                                                       | No       | HEAD                       |
 | version_new           | New version/ref for diff analysis                                                                  | No       | HEAD^                      |

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,7 @@ runs:
             PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
             if [[ "$PR_NUMBER" != "null" && "${{ inputs.allow_pr_comment }}" == "true" ]]; then
                 # Check if a comment from this action exists
-                COMMENT_ID=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments" | jq -r ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"Dirty Waters Analysis\")) | .id")
+                COMMENT_ID=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments" | jq -r ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"Software Supply Chain Report of ${{ inputs.project_repo }}\")) | .id")
 
                 # Set the appropriate URL and HTTP method based on whether a comment exists
                 if [[ -z "$COMMENT_ID" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -261,5 +261,6 @@ runs:
         key: dirty-waters-cache-${{ runner.os }}-${{ inputs.project_repo }}-${{ steps.set-sha.outputs.commit_sha }}
 
     - name: Break CI if analyses fail
-      run: exit $(( steps.analysis.outcome == 'failure' ))
+      run: |
+        [[ "${{ steps.analysis.outcome }}" == "failure" ]] && exit 1 || exit 0
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,6 @@ inputs:
   dirty_waters_version:
     description: 'Dirty Waters version to use, defaults to latest'
     required: false
-    default: 'HEAD'
   project_repo:
     description: 'Project repository path (as in GitHub)'
     required: false
@@ -125,9 +124,13 @@ runs:
       run: |
         git clone https://github.com/chains-project/dirty-waters.git
         cd dirty-waters
-        if [ "${{ inputs.dirty_waters_version }}" != "HEAD" ]; then
-          git checkout ${{ inputs.dirty_waters_version }}
+        if [ !"${{ inputs.dirty_waters_version }}" ]; then
+          checkout_version=$(git tag --sort=-creatordate | head -n1)
+        else
+          checkout_version=${{ inputs.dirty_waters_version }}
         fi
+        echo "Checking out dirty-waters to version $checkout_version"
+        git checkout ${{ inputs.dirty_waters_version }}
         pip install -r requirements.txt
 
     - name: Run analysis

--- a/action.yml
+++ b/action.yml
@@ -229,14 +229,27 @@ runs:
             # Handle PR comments
             PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
             if [[ "$PR_NUMBER" != "null" && "${{ inputs.allow_pr_comment }}" == "true" ]]; then
-                # make a new comment with the report in the body if no comment from this action exists;
-                # if a comment from this action exists, edit it
+                # Check if a comment from this action exists
                 COMMENT_ID=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments" | jq -r ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"Dirty Waters Analysis\")) | .id")
-                echo "[DEBUG] Commenting on PR, comment ID is $COMMENT_ID"
-                curl -s -X POST \
+
+                # Set the appropriate URL and HTTP method based on whether a comment exists
+                if [[ -z "$COMMENT_ID" ]]; then
+                    # No existing comment - create new one
+                    COMMENT_URL="https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments"
+                    HTTP_METHOD="POST"
+                else
+                    # Comment exists - edit it
+                    COMMENT_URL="https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments/${COMMENT_ID}"
+                    HTTP_METHOD="PATCH"  # Use PATCH to update an existing comment
+                fi
+
+                echo "[DEBUG] ${HTTP_METHOD} comment to $COMMENT_URL"
+
+                # Single curl command using the determined URL and method
+                curl -s -X $HTTP_METHOD \
                     -H "Accept: application/vnd.github.v3+json" \
                     -H "Authorization: token $GITHUB_TOKEN" \
-                    "https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments/${COMMENT_ID}" \
+                    "$COMMENT_URL" \
                     -d "$(jq -n --arg body "$COMMENT" '{body: $body}')"
             fi
 

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,6 @@ inputs:
   github_token:
     description: "GitHub token"
     required: true
-  dirty_waters_version:
-    description: 'Dirty Waters version to use, defaults to latest'
-    required: false
   project_repo:
     description: 'Project repository path (as in GitHub)'
     required: false
@@ -124,13 +121,9 @@ runs:
       run: |
         git clone https://github.com/chains-project/dirty-waters.git
         cd dirty-waters
-        if [ !"${{ inputs.dirty_waters_version }}" ]; then
-          checkout_version=$(git tag --sort=-creatordate | head -n1)
-        else
-          checkout_version=${{ inputs.dirty_waters_version }}
-        fi
-        echo "Checking out dirty-waters to version $checkout_version"
-        git checkout ${{ inputs.dirty_waters_version }}
+        # The version is pinned to the latest dirty-waters release at the time of the action release
+        DIRTY_WATERS_VERSION="v0.50.0"
+        git checkout $DIRTY_WATERS_VERSION
         pip install -r requirements.txt
 
     - name: Run analysis

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
         git clone https://github.com/chains-project/dirty-waters.git
         cd dirty-waters
         # The version is pinned to the latest dirty-waters release at the time of the action release
-        DIRTY_WATERS_VERSION="11be42866728d32ad9e89a35266ca5f29cf09fb7"
+        DIRTY_WATERS_VERSION="98952a5a8f08a740e477e6bc1e5b468765af2829"
         git checkout $DIRTY_WATERS_VERSION
         pip install -r requirements.txt
 

--- a/action.yml
+++ b/action.yml
@@ -200,7 +200,8 @@ runs:
 
         # Check for high severity issues
         if [ "${{ inputs.fail_on_high_severity }}" == "true" ]; then
-            if [[ $(cat "$latest_report" | grep -o "(⚠️⚠️⚠️) [0-9]*" | grep -o "[0-9]*" | sort -nr | head -n1) -gt 0 ]]; then
+            echo "[DEBUG] Fails on high severity, checking for any high severity issues"
+            if [[ $(cat "$latest_report" | grep -o "(⚠️⚠️⚠️): [0-9]*" | grep -o "[0-9]*" | sort -nr | head -n1) -gt 0 ]]; then
                 echo "High severity issues found. CI will fail."
                 CI_WILL_FAIL=1
             fi
@@ -208,9 +209,11 @@ runs:
 
         # Only check for threshold violations if we haven't already decided to fail
         if [ $CI_WILL_FAIL -eq 0 ]; then
+            echo "[DEBUG] Haven't decided to fail yet, checking for threshold being surpassed"
             total_packages=$(cat "$latest_report" | grep -o "Total packages in the supply chain: [0-9]*" | grep -o "[0-9]*")
             for severity in "⚠️⚠️⚠️" "⚠️⚠️" "⚠️"; do
-                for count in $(cat "$latest_report" | grep -o "($severity) [0-9]*" | grep -o "[0-9]*"); do
+                for count in $(cat "$latest_report" | grep -o "($severity): [0-9]*" | grep -o "[0-9]*"); do
+                    echo "[DEBUG] Count for $severity is $count"
                     if [[ $(echo "scale=2; $count / $total_packages * 100" | bc) -gt ${{ inputs.x_to_fail }} ]]; then
                         echo "Number of $severity issues surpasses the threshold. CI will fail."
                         CI_WILL_FAIL=1
@@ -222,6 +225,7 @@ runs:
 
         # Handle comments only if CI will fail
         if [ $CI_WILL_FAIL -eq 1 ]; then
+            echo "[DEBUG] CI will fail"
             # Handle PR comments
             PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
             if [[ "$PR_NUMBER" != "null" && "${{ inputs.allow_pr_comment }}" == "true" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -232,6 +232,7 @@ runs:
                 # make a new comment with the report in the body if no comment from this action exists;
                 # if a comment from this action exists, edit it
                 COMMENT_ID=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments" | jq -r ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"Dirty Waters Analysis\")) | .id")
+                echo "[DEBUG] Commenting on PR, comment ID is $COMMENT_ID"
                 curl -s -X POST \
                     -H "Accept: application/vnd.github.v3+json" \
                     -H "Authorization: token $GITHUB_TOKEN" \

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5.4.0
       with:
         python-version: '3.12'
 
@@ -108,7 +108,7 @@ runs:
         fi
 
     - name: Restore cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v4.2.1
       id: restore-cache
       if: inputs.ignore_cache != 'true'
       with:
@@ -248,7 +248,7 @@ runs:
         fi
 
     - name: Save cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v4.2.1
       if: always()
       with:
         path: tool/cache

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
         git clone https://github.com/chains-project/dirty-waters.git
         cd dirty-waters
         # The version is pinned to the latest dirty-waters release at the time of the action release
-        DIRTY_WATERS_VERSION="938ed4818c74c361f185dad392e81561c42ab87c"
+        DIRTY_WATERS_VERSION="f13187f11b2ee8363b5a41f49acfca6af3fb159f"
         git checkout $DIRTY_WATERS_VERSION
         pip install -r requirements.txt
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,8 @@ inputs:
     default: 'HEAD'
   project_repo:
     description: 'Project repository path (as in GitHub)'
-    required: true
+    required: false
+    default: '${{ github.repository }}'
   version_old:
     description: 'Release version to analyze - old if differential analysis'
     required: false
@@ -67,10 +68,12 @@ inputs:
     default: 'false'
   latest_commit_sha:
     description: 'Latest commit SHA from the project using this action, using for commenting on commits'
-    required: true
+    required: false
+    default: '${{ github.sha }}'
   github_event_before:
     description: 'GitHub event before SHA, to retrieve the previous cache key'
-    required: true
+    required: false
+    default: '${{ github.event.before }}'
   ignore_cache:
     description: 'Ignore the repository cache for this run'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
         git clone https://github.com/chains-project/dirty-waters.git
         cd dirty-waters
         # The version is pinned to the latest dirty-waters release at the time of the action release
-        DIRTY_WATERS_VERSION="f13187f11b2ee8363b5a41f49acfca6af3fb159f"
+        DIRTY_WATERS_VERSION="11be42866728d32ad9e89a35266ca5f29cf09fb7"
         git checkout $DIRTY_WATERS_VERSION
         pip install -r requirements.txt
 

--- a/action.yml
+++ b/action.yml
@@ -239,7 +239,7 @@ runs:
                     HTTP_METHOD="POST"
                 else
                     # Comment exists - edit it
-                    COMMENT_URL="https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments/${COMMENT_ID}"
+                    COMMENT_URL="https://api.github.com/repos/${{ inputs.project_repo }}/issues/comments/${COMMENT_ID}"
                     HTTP_METHOD="PATCH"  # Use PATCH to update an existing comment
                 fi
 

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
         git clone https://github.com/chains-project/dirty-waters.git
         cd dirty-waters
         # The version is pinned to the latest dirty-waters release at the time of the action release
-        DIRTY_WATERS_VERSION="a5409a1ab6d9cf6f2ba3644d66f5733fa3f3518a"
+        DIRTY_WATERS_VERSION="938ed4818c74c361f185dad392e81561c42ab87c"
         git checkout $DIRTY_WATERS_VERSION
         pip install -r requirements.txt
 

--- a/action.yml
+++ b/action.yml
@@ -42,10 +42,10 @@ inputs:
     description: 'Enable debug mode'
     required: false
     default: 'false'
-  no_gradual_report:
-    description: 'Disable gradual report functionality'
+  gradual_report:
+    description: 'Enable gradual report functionality'
     required: false
-    default: 'false'
+    default: 'true'
   fail_on_high_severity:
     description: 'Break CI if high severity issues are found'
     required: false
@@ -163,8 +163,8 @@ runs:
             CMD="$CMD --debug"
         fi
 
-        if [ "${{ inputs.no_gradual_report }}" == "true" ]; then
-            CMD="$CMD --no-gradual-report"
+        if [ "${{ inputs.gradual_report }}" == "false" ]; then
+            CMD="$CMD --gradual-report=false"
         fi
 
         echo "Running command: $CMD"

--- a/action.yml
+++ b/action.yml
@@ -225,10 +225,13 @@ runs:
             # Handle PR comments
             PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
             if [[ "$PR_NUMBER" != "null" && "${{ inputs.allow_pr_comment }}" == "true" ]]; then
+                # make a new comment with the report in the body if no comment from this action exists;
+                # if a comment from this action exists, edit it
+                COMMENT_ID=$(curl -s -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments" | jq -r ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"Dirty Waters Analysis\")) | .id")
                 curl -s -X POST \
                     -H "Accept: application/vnd.github.v3+json" \
                     -H "Authorization: token $GITHUB_TOKEN" \
-                    "https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments" \
+                    "https://api.github.com/repos/${{ inputs.project_repo }}/issues/$PR_NUMBER/comments/${COMMENT_ID}" \
                     -d "$(jq -n --arg body "$COMMENT" '{body: $body}')"
             fi
 

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
         git clone https://github.com/chains-project/dirty-waters.git
         cd dirty-waters
         # The version is pinned to the latest dirty-waters release at the time of the action release
-        DIRTY_WATERS_VERSION="v0.50.0"
+        DIRTY_WATERS_VERSION="a5409a1ab6d9cf6f2ba3644d66f5733fa3f3518a"
         git checkout $DIRTY_WATERS_VERSION
         pip install -r requirements.txt
 

--- a/example_workflow.yml
+++ b/example_workflow.yml
@@ -43,5 +43,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: npm # Change this according to your project
           allow_pr_comment: true # Optional: comments on PRs if high severity issues are found
-          comment_on_commit: true # Optional: comments on commits (if not PR/if above is false) if high severity issues are found
+          comment_on_commit: false # Optional: comments on commits (if not PR/if above is false) if high severity issues are found
+          gradual_report: false
           ignore_cache: ${{ github.event.inputs.ignore_cache }}

--- a/example_workflow.yml
+++ b/example_workflow.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           # example args, change as needed
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          dirty_waters_version: v0.49.0
           package_manager: npm # Change this according to your project
           allow_pr_comment: true # Optional: comments on PRs if high severity issues are found
           comment_on_commit: true # Optional: comments on commits (if not PR/if above is false) if high severity issues are found

--- a/example_workflow.yml
+++ b/example_workflow.yml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/example_workflow.yml
+++ b/example_workflow.yml
@@ -34,15 +34,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Check if first dirty-waters run
-        id: check-first-run
-        run: |
-          WORKFLOW_FILE=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | select(.name == "${{ github.workflow }}") | .path' | xargs basename)
-          RUNS=$(gh api repos/${{ github.repository }}/actions/workflows/$WORKFLOW_FILE/runs --jq '[.workflow_runs[] | select(.conclusion=="success")] | length')
-          echo "is_first_run=$([[ $RUNS -le 1 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run Static Dirty Waters analysis
         id: static-analysis
         if: steps.check-first-run.outputs.is_first_run == 'true'
@@ -51,20 +42,6 @@ jobs:
           # example args, change as needed
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dirty_waters_version: v0.49.0
-          package_manager: npm # Change this according to your project
-          allow_pr_comment: true # Optional: comments on PRs if high severity issues are found
-          comment_on_commit: true # Optional: comments on commits (if not PR/if above is false) if high severity issues are found
-          ignore_cache: ${{ github.event.inputs.ignore_cache }}
-
-      - name: Run Differential Dirty Waters Analysis
-        id: differential-analysis
-        if: steps.check-first-run.outputs.is_first_run != 'true'
-        uses: chains-project/dirty-waters-action@v1.10
-        with:
-          # example args, change as needed
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dirty_waters_version: v0.49.0
-          differential_analysis: true
           package_manager: npm # Change this according to your project
           allow_pr_comment: true # Optional: comments on PRs if high severity issues are found
           comment_on_commit: true # Optional: comments on commits (if not PR/if above is false) if high severity issues are found

--- a/example_workflow.yml
+++ b/example_workflow.yml
@@ -20,15 +20,19 @@ on:
         required: false
         default: "false"
 
+permissions: read-all
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
     permissions:
-      persist-credentials: false
+      pull-requests: write
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check if first dirty-waters run
         id: check-first-run


### PR DESCRIPTION
cc @ericcornelissen , also see https://github.com/chains-project/dirty-waters/pull/84 + https://github.com/chains-project/dirty-waters/commit/70185e94fb3315db1fe043ae3437d167d5d9cb0c

Here, the following:
- removed path filters from example workflow
- set persist-credentials to false in example workflow
- pin dirty-waters (and action) in example workflow; every release of the action will be pinned to the latest tag of dirty-waters, at the time of release
- stopped requiring project_repo, latest_commit_sha, github_event_before as inputs
- switched to major-minor-patch versioning
- switched to one comment per PR, at most (updating the first one, to avoid new notifications)
- bug fixes